### PR TITLE
Remove `set iappl 0` run

### DIFF
--- a/nnpdf31_proc/launch/ATLASTOPDIFF8TEVTRAPNORM.txt
+++ b/nnpdf31_proc/launch/ATLASTOPDIFF8TEVTRAPNORM.txt
@@ -14,10 +14,6 @@ set lhaid 324900
 set dynamical_scale_choice 10
 set reweight_scale False
 set req_acc_FO 0.01
-set iappl 0
-done
-launch ATLASTOPDIFF8TEVTRAPNORM
-fixed_order = ON
 set iappl 1
 done
 launch ATLASTOPDIFF8TEVTRAPNORM
@@ -26,5 +22,3 @@ set req_acc_FO 0.001
 set iappl 2
 done
 quit
-
-

--- a/nnpdf31_proc/launch/ATLASTTBARTOT13TEV.txt
+++ b/nnpdf31_proc/launch/ATLASTTBARTOT13TEV.txt
@@ -17,10 +17,6 @@ set mur_ref_fixed 172.5
 set muf_ref_fixed 172.5
 set reweight_scale False
 set req_acc_FO 0.01
-set iappl 0
-done
-launch ATLASTTBARTOT13TEV
-fixed_order = ON
 set iappl 1
 done
 launch ATLASTTBARTOT13TEV
@@ -29,5 +25,3 @@ set req_acc_FO 0.001
 set iappl 2
 done
 quit
-
-

--- a/nnpdf31_proc/launch/ATLASTTBARTOT7TEV.txt
+++ b/nnpdf31_proc/launch/ATLASTTBARTOT7TEV.txt
@@ -17,10 +17,6 @@ set mur_ref_fixed 172.5
 set muf_ref_fixed 172.5
 set reweight_scale False
 set req_acc_FO 0.01
-set iappl 0
-done
-launch ATLASTTBARTOT7TEV
-fixed_order = ON
 set iappl 1
 done
 launch ATLASTTBARTOT7TEV
@@ -29,5 +25,3 @@ set req_acc_FO 0.001
 set iappl 2
 done
 quit
-
-

--- a/nnpdf31_proc/launch/ATLASTTBARTOT8TEV.txt
+++ b/nnpdf31_proc/launch/ATLASTTBARTOT8TEV.txt
@@ -17,10 +17,6 @@ set mur_ref_fixed 172.5
 set muf_ref_fixed 172.5
 set reweight_scale False
 set req_acc_FO 0.01
-set iappl 0
-done
-launch ATLASTTBARTOT8TEV
-fixed_order = ON
 set iappl 1
 done
 launch ATLASTTBARTOT8TEV
@@ -29,5 +25,3 @@ set req_acc_FO 0.001
 set iappl 2
 done
 quit
-
-

--- a/nnpdf31_proc/launch/ATLASZHIGHMASS49FB.txt
+++ b/nnpdf31_proc/launch/ATLASZHIGHMASS49FB.txt
@@ -14,10 +14,6 @@ set reweight_scale False
 set ptl = 25.0
 set etal = 2.5
 set req_acc_FO 0.01
-set iappl 0
-done
-launch ATLASZHIGHMASS49FB
-fixed_order = ON
 set iappl 1
 done
 launch ATLASZHIGHMASS49FB

--- a/nnpdf31_proc/launch/CMSTOPDIFF8TEVTTRAPNORM.txt
+++ b/nnpdf31_proc/launch/CMSTOPDIFF8TEVTTRAPNORM.txt
@@ -14,10 +14,6 @@ set lhaid 324900
 set dynamical_scale_choice 10
 set reweight_scale False
 set req_acc_FO 0.01
-set iappl 0
-done
-launch CMSTOPDIFF8TEVTTRAPNORM
-fixed_order = ON
 set iappl 1
 done
 launch CMSTOPDIFF8TEVTTRAPNORM
@@ -26,5 +22,3 @@ set req_acc_FO 0.001
 set iappl 2
 done
 quit
-
-

--- a/nnpdf31_proc/launch/CMSTTBARTOT13TEV.txt
+++ b/nnpdf31_proc/launch/CMSTTBARTOT13TEV.txt
@@ -17,10 +17,6 @@ set mur_ref_fixed 172.5
 set muf_ref_fixed 172.5
 set reweight_scale False
 set req_acc_FO 0.01
-set iappl 0
-done
-launch CMSTTBARTOT13TEV
-fixed_order = ON
 set iappl 1
 done
 launch CMSTTBARTOT13TEV
@@ -29,5 +25,3 @@ set req_acc_FO 0.001
 set iappl 2
 done
 quit
-
-

--- a/nnpdf31_proc/launch/CMSTTBARTOT7TEV.txt
+++ b/nnpdf31_proc/launch/CMSTTBARTOT7TEV.txt
@@ -17,10 +17,6 @@ set mur_ref_fixed 172.5
 set muf_ref_fixed 172.5
 set reweight_scale False
 set req_acc_FO 0.01
-set iappl 0
-done
-launch CMSTTBARTOT7TEV
-fixed_order = ON
 set iappl 1
 done
 launch CMSTTBARTOT7TEV
@@ -29,5 +25,3 @@ set req_acc_FO 0.001
 set iappl 2
 done
 quit
-
-

--- a/nnpdf31_proc/launch/CMSTTBARTOT8TEV.txt
+++ b/nnpdf31_proc/launch/CMSTTBARTOT8TEV.txt
@@ -17,10 +17,6 @@ set mur_ref_fixed 172.5
 set muf_ref_fixed 172.5
 set reweight_scale False
 set req_acc_FO 0.01
-set iappl 0
-done
-launch CMSTTBARTOT8TEV
-fixed_order = ON
 set iappl 1
 done
 launch CMSTTBARTOT8TEV
@@ -29,5 +25,3 @@ set req_acc_FO 0.001
 set iappl 2
 done
 quit
-
-


### PR DESCRIPTION
This commit removes the `set iappl 0` run which doesn't produce grids and is therefore seems to be superfluous - @enocera @marcozaro could you please double check this?
