### PR TITLE
Add CMSDY2D12 dataset

### DIFF
--- a/nnpdf31_proc/CMSDY2D12/analysis.f
+++ b/nnpdf31_proc/CMSDY2D12/analysis.f
@@ -1,0 +1,139 @@
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_begin(nwgt,weights_info)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      integer nwgt
+      character*(*) weights_info(*)
+
+      call set_error_estimation(1)
+      call HwU_inithist(nwgt,weights_info)
+      call HwU_book(1,'lmlp m yrap', 24,  20d0*2.4d0,   30d0*2.4d0)
+      call HwU_book(2,'lmlp m yrap', 24,  30d0*2.4d0,   45d0*2.4d0)
+      call HwU_book(3,'lmlp m yrap', 24,  45d0*2.4d0,   60d0*2.4d0)
+      call HwU_book(4,'lmlp m yrap', 24,  60d0*2.4d0,  120d0*2.4d0)
+      call HwU_book(5,'lmlp m yrap', 24, 120d0*2.4d0,  200d0*2.4d0)
+      call HwU_book(6,'lmlp m yrap', 12, 200d0*2.4d0, 1500d0*2.4d0)
+
+      return
+      end
+
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_end(dummy)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      double precision dummy
+      call HwU_write_file
+      return                
+      end
+
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_fill(p,istatus,ipdg,wgts,ibody)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      include 'nexternal.inc'
+      include 'cuts.inc'
+      integer istatus(nexternal)
+      integer iPDG(nexternal)
+      integer ibody  
+      integer i
+      integer j
+      double precision p(0:4,nexternal)
+      double precision wgts(*)
+      double precision ppl(0:3), pplb(0:3), ppv(0:3), xmll, getinvm
+      double precision xyll, getabsy
+      external getinvm
+      external getabsy
+      integer bin
+      double precision minmll, maxmll
+
+      double precision p_reco(0:4,nexternal)
+      integer iPDG_reco(nexternal)
+
+
+
+      call recombine_momenta(rphreco, etaphreco, lepphreco, quarkphreco,
+     $                       p, iPDG, p_reco, iPDG_reco)
+
+      do j = nincoming+1, nexternal
+        if (iPDG_reco(j).eq.13) ppl(0:3)=p_reco(0:3,j)
+        if (iPDG_reco(j).eq.-13) pplb(0:3)=p_reco(0:3,j)
+      enddo
+      do i=0,3
+        ppv(i)=ppl(i)+pplb(i)
+      enddo
+
+      xmll=getinvm(ppv(0),ppv(1),ppv(2),ppv(3))
+      xyll=getabsy(ppv(0),ppv(3))
+
+      bin = -1
+
+      if (xmll.ge.20d0.and.xmll.lt.30d0) then
+        bin=1
+        minmll=20d0
+        maxmll=30d0
+      elseif (xmll.ge.30d0.and.xmll.lt.45d0) then
+        bin=2
+        minmll=30d0
+        maxmll=45d0
+      elseif (xmll.ge.45d0.and.xmll.lt.60d0) then
+        bin=3
+        minmll=45d0
+        maxmll=60d0
+      elseif (xmll.ge.60d0.and.xmll.lt.120d0) then
+        bin=4
+        minmll=60d0
+        maxmll=120d0
+      elseif (xmll.ge.120d0.and.xmll.lt.200d0) then
+        bin=5
+        minmll=120d0
+        maxmll=200d0
+      elseif (xmll.ge.200d0.and.xmll.lt.1500d0) then
+        bin=6
+        minmll=200d0
+        maxmll=1500d0
+      endif
+
+      call HwU_fill(bin,minmll*2.4+xyll*(maxmll-minmll),wgts)
+
+
+ 999  return      
+      end
+
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      function getinvm(en,ptx,pty,pl)
+      implicit none
+      real*8 getinvm,en,ptx,pty,pl,tiny,tmp
+      parameter (tiny=1.d-5)
+c
+      tmp=en**2-ptx**2-pty**2-pl**2
+      if(tmp.gt.0.d0)then
+        tmp=sqrt(tmp)
+      elseif(tmp.gt.-tiny)then
+        tmp=0.d0
+      else
+        write(*,*)'Attempt to compute a negative mass'
+        stop
+      endif
+      getinvm=tmp
+      return
+      end
+
+      function getabsy(en,pl)
+      implicit none
+      real*8 getabsy,en,pl,tmp
+c
+      tmp=pl/en
+      if(abs(tmp).lt.1d0)then
+        tmp=abs(atanh(tmp))
+      else
+        write(*,*)'Attempt to compute atanh(x) with x > 1'
+        stop
+      endif
+      getabsy=tmp
+      return
+      end
+

--- a/nnpdf31_proc/CMSDY2D12/change_scale_to_mll_midpoint.patch
+++ b/nnpdf31_proc/CMSDY2D12/change_scale_to_mll_midpoint.patch
@@ -1,0 +1,67 @@
+--- CMSDY2D11/SubProcesses/setscales.f	2020-05-21 17:23:55.126143088 +0200
++++ CMSDY2D11/SubProcesses/setscales.f.new	2020-05-21 17:27:26.262700419 +0200
+@@ -527,6 +527,17 @@
+       integer i,j
+       character*80 temp_scale_id
+       common/ctemp_scale_id/temp_scale_id
++      integer iPDG_reco(nexternal)
++      double precision ppl(0:3), pplb(0:3), ppv(0:3), xmll
++      double precision p_reco(0:4,nexternal), p_in(0:4,nexternal)
++c     les houches accord stuff to identify particles
++c
++      integer idup(nexternal,maxproc),mothup(2,nexternal,maxproc),
++     &        icolup(2,nexternal,maxflow),niprocs
++      common /c_leshouche_inc/idup,mothup,icolup,niprocs
++c Masses of external particles
++      double precision pmass(nexternal)
++      common/to_mass/pmass
+ c
+       tmp=0
+       if(ickkw.eq.-1)then
+@@ -568,10 +579,42 @@
+ cc                 dynamical_scale_choice = 10                                   cc
+ cc      in the run_card (run_card.dat)                                           cc
+ ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+-         write(*,*) "User-defined scale not set"
+-         stop 1
+-         temp_scale_id='User-defined dynamical scale' ! use a meaningful string
+-         tmp = 0d0
++         temp_scale_id='CMSDY2D11' ! use a meaningful string
++         tmp = -1d0
++         do i=1,nexternal
++           p_in(0:3,i) = pp(0:3,i)
++           p_in(4,i) = pmass(i)
++         enddo
++         call recombine_momenta(rphreco, etaphreco, lepphreco, quarkphreco,
++     $                          p_in, idup(1,1), p_reco, iPDG_reco)
++
++         do j = nincoming+1, nexternal
++           if (iPDG_reco(j).eq.13) ppl(0:3)=p_reco(0:3,j)
++           if (iPDG_reco(j).eq.-13) pplb(0:3)=p_reco(0:3,j)
++         enddo
++         do i=0,3
++           ppv(i)=ppl(i)+pplb(i)
++         enddo
++
++         xmll=sqrt(ppv(0)**2-ppv(1)**2-ppv(2)**2-ppv(3)**2)
++
++         if (xmll.ge.20d0.and.xmll.lt.30d0) then
++           tmp=20d0+(30d0-20d0)/2d0
++         elseif (xmll.ge.30d0.and.xmll.lt.45d0) then
++           tmp=30d0+(45d0-30d0)/2d0
++         elseif (xmll.ge.45d0.and.xmll.lt.60d0) then
++           tmp=45d0+(60d0-45d0)/2d0
++         elseif (xmll.ge.60d0.and.xmll.lt.120d0) then
++           tmp=60d0+(120d0-60d0)/2d0
++         elseif (xmll.ge.120d0.and.xmll.lt.200d0) then
++           tmp=120d0+(200d0-120d0)/2d0
++         elseif (xmll.ge.200d0.and.xmll.lt.1500d0) then
++           tmp=200d0+(1500d0-200d0)/2d0
++         else
++c          may happen during checks when cuts are not applied
++           write(*,*) "Error: wrong invariant mass:", xmll
++           tmp=xmll
++         endif
+ ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+ cc      USER-DEFINED SCALE: END OF USER CODE                                     cc
+ ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/nnpdf31_proc/CMSDY2D12/launch.txt
+++ b/nnpdf31_proc/CMSDY2D12/launch.txt
@@ -1,0 +1,20 @@
+launch @OUTPUT@
+fixed_order = ON
+set mz @MZ@
+set ymt @YMT@
+set ebeam1 4000
+set ebeam2 4000
+set pdlabel lhapdf
+set lhaid 324900
+set dynamical_scale_choice 10
+set reweight_scale True
+#user_defined_cut set ptl1min = 20.0
+set ptl = 10.0
+#user_defined_cut set yll = 2.4
+set etal = 2.4
+set mll_sf = 20.0
+#user_defined_cut set mmllmax = 1500.0
+set req_acc_FO 0.0001
+set iappl 1
+done
+quit

--- a/nnpdf31_proc/CMSDY2D12/output.txt
+++ b/nnpdf31_proc/CMSDY2D12/output.txt
@@ -1,0 +1,7 @@
+set complex_mass_scheme True
+import model loop_qcd_qed_sm_Gmu
+define p = p b b~
+define j = p
+generate p p > mu+ mu- [QCD QED]
+output @OUTPUT@
+quit


### PR DESCRIPTION
This branch adds the CMSDY2D12 dataset from [arXiv:1412.1115](https://arxiv.org/abs/1412.1115), with data at [10.17182/hepdata.69869](https://doi.org/10.17182/hepdata.69869). The runcards were copied from CMSDY2D11 dataset, with the following changes: beam energy increased from 3.5 TeV to 4 TeV, leading and subleading lepton pt increased to 20 GeV and 10 GeV, respectively.

Issues:
- the data available on hepdata.net seems not to include post-FSR data, only pre-FSR data (bad!)
- it is unclear which scale is used in NNPDF3.1. For the time being the same as in CMSDY2D11 is used
- In this dataset the first invariant-mass bin from 20 to 30 GeV is zero at LO because of the more stringent pt cuts on the leptons. At LO the smallest invariant mass in two times the leading lepton pt, which is 40 GeV, meaning that even the second is only filled for the last 5 GeV, that is 40-45 GeV