### PR TITLE
Add CMS single-top runcards

### DIFF
--- a/nnpdf31_proc/CMS_SINGLETOP_TCH_R_13TEV_T/analysis.f
+++ b/nnpdf31_proc/CMS_SINGLETOP_TCH_R_13TEV_T/analysis.f
@@ -1,0 +1,43 @@
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_begin(nwgt,weights_info)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      integer nwgt
+      character*(*) weights_info(*)
+
+      call set_error_estimation(1)
+      call HwU_inithist(nwgt,weights_info)
+      call HwU_book(1,'total', 1,0d0,1d0)
+
+      return
+      end
+
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_end(dummy)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      double precision dummy
+      call HwU_write_file
+      return
+      end
+
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_fill(p,istatus,ipdg,wgts,ibody)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      include 'nexternal.inc'
+      integer istatus(nexternal)
+      integer iPDG(nexternal)
+      integer ibody
+      double precision p(0:4,nexternal)
+      double precision wgts(*)
+
+      call HwU_fill(1,0.5d0,wgts)
+
+ 999  return
+      end
+
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/nnpdf31_proc/CMS_SINGLETOP_TCH_R_13TEV_T/launch.txt
+++ b/nnpdf31_proc/CMS_SINGLETOP_TCH_R_13TEV_T/launch.txt
@@ -1,0 +1,23 @@
+launch @OUTPUT@
+fixed_order = ON
+set mt @MT@
+set mz @MZ@
+set mw @MW@
+set ymt @YMT@
+set ebeam1 6500
+set ebeam2 6500
+set pdlabel lhapdf
+set lhaid 324900
+set fixed_ren_scale True
+set fixed_fac_scale True
+set mur_ref_fixed @MT@
+set muf_ref_fixed @MT@
+set reweight_scale True
+set jetalgo -1
+set jetradius 0.5
+set ptj 40.0
+set etaj 4.7
+set req_acc_FO 0.005
+set pineappl True
+done
+quit

--- a/nnpdf31_proc/CMS_SINGLETOP_TCH_R_13TEV_T/output.txt
+++ b/nnpdf31_proc/CMS_SINGLETOP_TCH_R_13TEV_T/output.txt
@@ -1,0 +1,6 @@
+import model loop_qcd_qed_sm_Gmu
+define p = p b b~
+define j = p
+generate p p > t j [QCD]
+output @OUTPUT@
+quit

--- a/nnpdf31_proc/CMS_SINGLETOP_TCH_R_13TEV_TB/analysis.f
+++ b/nnpdf31_proc/CMS_SINGLETOP_TCH_R_13TEV_TB/analysis.f
@@ -1,0 +1,43 @@
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_begin(nwgt,weights_info)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      integer nwgt
+      character*(*) weights_info(*)
+
+      call set_error_estimation(1)
+      call HwU_inithist(nwgt,weights_info)
+      call HwU_book(1,'total', 1,0d0,1d0)
+
+      return
+      end
+
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_end(dummy)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      double precision dummy
+      call HwU_write_file
+      return
+      end
+
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_fill(p,istatus,ipdg,wgts,ibody)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      include 'nexternal.inc'
+      integer istatus(nexternal)
+      integer iPDG(nexternal)
+      integer ibody
+      double precision p(0:4,nexternal)
+      double precision wgts(*)
+
+      call HwU_fill(1,0.5d0,wgts)
+
+ 999  return
+      end
+
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/nnpdf31_proc/CMS_SINGLETOP_TCH_R_13TEV_TB/launch.txt
+++ b/nnpdf31_proc/CMS_SINGLETOP_TCH_R_13TEV_TB/launch.txt
@@ -1,0 +1,23 @@
+launch @OUTPUT@
+fixed_order = ON
+set mt @MT@
+set mz @MZ@
+set mw @MW@
+set ymt @YMT@
+set ebeam1 6500
+set ebeam2 6500
+set pdlabel lhapdf
+set lhaid 324900
+set fixed_ren_scale True
+set fixed_fac_scale True
+set mur_ref_fixed @MT@
+set muf_ref_fixed @MT@
+set reweight_scale True
+set jetalgo -1
+set jetradius 0.5
+set ptj 40.0
+set etaj 4.7
+set req_acc_FO 0.005
+set pineappl True
+done
+quit

--- a/nnpdf31_proc/CMS_SINGLETOP_TCH_R_13TEV_TB/output.txt
+++ b/nnpdf31_proc/CMS_SINGLETOP_TCH_R_13TEV_TB/output.txt
@@ -1,0 +1,6 @@
+import model loop_qcd_qed_sm_Gmu
+define p = p b b~
+define j = p
+generate p p > t~ j [QCD]
+output @OUTPUT@
+quit

--- a/nnpdf31_proc/CMS_SINGLETOP_TCH_R_7TEV_T/analysis.f
+++ b/nnpdf31_proc/CMS_SINGLETOP_TCH_R_7TEV_T/analysis.f
@@ -1,0 +1,43 @@
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_begin(nwgt,weights_info)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      integer nwgt
+      character*(*) weights_info(*)
+
+      call set_error_estimation(1)
+      call HwU_inithist(nwgt,weights_info)
+      call HwU_book(1,'total', 1,0d0,1d0)
+
+      return
+      end
+
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_end(dummy)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      double precision dummy
+      call HwU_write_file
+      return
+      end
+
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_fill(p,istatus,ipdg,wgts,ibody)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      include 'nexternal.inc'
+      integer istatus(nexternal)
+      integer iPDG(nexternal)
+      integer ibody
+      double precision p(0:4,nexternal)
+      double precision wgts(*)
+
+      call HwU_fill(1,0.5d0,wgts)
+
+ 999  return
+      end
+
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/nnpdf31_proc/CMS_SINGLETOP_TCH_R_7TEV_T/launch.txt
+++ b/nnpdf31_proc/CMS_SINGLETOP_TCH_R_7TEV_T/launch.txt
@@ -1,0 +1,23 @@
+launch @OUTPUT@
+fixed_order = ON
+set mt @MT@
+set mz @MZ@
+set mw @MW@
+set ymt @YMT@
+set ebeam1 3500
+set ebeam2 3500
+set pdlabel lhapdf
+set lhaid 324900
+set fixed_ren_scale True
+set fixed_fac_scale True
+set mur_ref_fixed @MT@
+set muf_ref_fixed @MT@
+set reweight_scale True
+set jetalgo -1
+set jetradius 0.5
+set ptj 30.0
+set etaj 4.5
+set req_acc_FO 0.005
+set pineappl True
+done
+quit

--- a/nnpdf31_proc/CMS_SINGLETOP_TCH_R_7TEV_T/output.txt
+++ b/nnpdf31_proc/CMS_SINGLETOP_TCH_R_7TEV_T/output.txt
@@ -1,0 +1,6 @@
+import model loop_qcd_qed_sm_Gmu
+define p = p b b~
+define j = p
+generate p p > t j [QCD]
+output @OUTPUT@
+quit

--- a/nnpdf31_proc/CMS_SINGLETOP_TCH_R_7TEV_TB/analysis.f
+++ b/nnpdf31_proc/CMS_SINGLETOP_TCH_R_7TEV_TB/analysis.f
@@ -1,0 +1,43 @@
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_begin(nwgt,weights_info)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      integer nwgt
+      character*(*) weights_info(*)
+
+      call set_error_estimation(1)
+      call HwU_inithist(nwgt,weights_info)
+      call HwU_book(1,'total', 1,0d0,1d0)
+
+      return
+      end
+
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_end(dummy)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      double precision dummy
+      call HwU_write_file
+      return
+      end
+
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_fill(p,istatus,ipdg,wgts,ibody)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      include 'nexternal.inc'
+      integer istatus(nexternal)
+      integer iPDG(nexternal)
+      integer ibody
+      double precision p(0:4,nexternal)
+      double precision wgts(*)
+
+      call HwU_fill(1,0.5d0,wgts)
+
+ 999  return
+      end
+
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/nnpdf31_proc/CMS_SINGLETOP_TCH_R_7TEV_TB/launch.txt
+++ b/nnpdf31_proc/CMS_SINGLETOP_TCH_R_7TEV_TB/launch.txt
@@ -1,0 +1,23 @@
+launch @OUTPUT@
+fixed_order = ON
+set mt @MT@
+set mz @MZ@
+set mw @MW@
+set ymt @YMT@
+set ebeam1 3500
+set ebeam2 3500
+set pdlabel lhapdf
+set lhaid 324900
+set fixed_ren_scale True
+set fixed_fac_scale True
+set mur_ref_fixed @MT@
+set muf_ref_fixed @MT@
+set reweight_scale True
+set jetalgo -1
+set jetradius 0.5
+set ptj 30.0
+set etaj 4.5
+set req_acc_FO 0.005
+set pineappl True
+done
+quit

--- a/nnpdf31_proc/CMS_SINGLETOP_TCH_R_7TEV_TB/output.txt
+++ b/nnpdf31_proc/CMS_SINGLETOP_TCH_R_7TEV_TB/output.txt
@@ -1,0 +1,6 @@
+import model loop_qcd_qed_sm_Gmu
+define p = p b b~
+define j = p
+generate p p > t~ j [QCD]
+output @OUTPUT@
+quit

--- a/nnpdf31_proc/CMS_SINGLETOP_TCH_R_8TEV_T/analysis.f
+++ b/nnpdf31_proc/CMS_SINGLETOP_TCH_R_8TEV_T/analysis.f
@@ -1,0 +1,43 @@
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_begin(nwgt,weights_info)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      integer nwgt
+      character*(*) weights_info(*)
+
+      call set_error_estimation(1)
+      call HwU_inithist(nwgt,weights_info)
+      call HwU_book(1,'total', 1,0d0,1d0)
+
+      return
+      end
+
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_end(dummy)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      double precision dummy
+      call HwU_write_file
+      return
+      end
+
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_fill(p,istatus,ipdg,wgts,ibody)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      include 'nexternal.inc'
+      integer istatus(nexternal)
+      integer iPDG(nexternal)
+      integer ibody
+      double precision p(0:4,nexternal)
+      double precision wgts(*)
+
+      call HwU_fill(1,0.5d0,wgts)
+
+ 999  return
+      end
+
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/nnpdf31_proc/CMS_SINGLETOP_TCH_R_8TEV_T/launch.txt
+++ b/nnpdf31_proc/CMS_SINGLETOP_TCH_R_8TEV_T/launch.txt
@@ -1,0 +1,24 @@
+launch @OUTPUT@
+fixed_order = ON
+set mt @MT@
+set mz @MZ@
+set mw @MW@
+set ymt @YMT@
+set ebeam1 4000
+set ebeam2 4000
+set pdlabel lhapdf
+set lhaid 324900
+set fixed_ren_scale True
+set fixed_fac_scale True
+set mur_ref_fixed @MT@
+set muf_ref_fixed @MT@
+set reweight_scale True
+set jetalgo -1
+set jetradius 0.5
+# the following should be ET > 40
+set ptj 40.0
+set etaj 4.5
+set req_acc_FO 0.005
+set pineappl True
+done
+quit

--- a/nnpdf31_proc/CMS_SINGLETOP_TCH_R_8TEV_T/output.txt
+++ b/nnpdf31_proc/CMS_SINGLETOP_TCH_R_8TEV_T/output.txt
@@ -1,0 +1,6 @@
+import model loop_qcd_qed_sm_Gmu
+define p = p b b~
+define j = p
+generate p p > t j [QCD]
+output @OUTPUT@
+quit

--- a/nnpdf31_proc/CMS_SINGLETOP_TCH_R_8TEV_TB/CMS_SINGLETOP_TCH_R_7TEV_TB/analysis.f
+++ b/nnpdf31_proc/CMS_SINGLETOP_TCH_R_8TEV_TB/CMS_SINGLETOP_TCH_R_7TEV_TB/analysis.f
@@ -1,0 +1,43 @@
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_begin(nwgt,weights_info)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      integer nwgt
+      character*(*) weights_info(*)
+
+      call set_error_estimation(1)
+      call HwU_inithist(nwgt,weights_info)
+      call HwU_book(1,'total', 1,0d0,1d0)
+
+      return
+      end
+
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_end(dummy)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      double precision dummy
+      call HwU_write_file
+      return
+      end
+
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_fill(p,istatus,ipdg,wgts,ibody)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      include 'nexternal.inc'
+      integer istatus(nexternal)
+      integer iPDG(nexternal)
+      integer ibody
+      double precision p(0:4,nexternal)
+      double precision wgts(*)
+
+      call HwU_fill(1,0.5d0,wgts)
+
+ 999  return
+      end
+
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/nnpdf31_proc/CMS_SINGLETOP_TCH_R_8TEV_TB/CMS_SINGLETOP_TCH_R_7TEV_TB/launch.txt
+++ b/nnpdf31_proc/CMS_SINGLETOP_TCH_R_8TEV_TB/CMS_SINGLETOP_TCH_R_7TEV_TB/launch.txt
@@ -1,0 +1,23 @@
+launch @OUTPUT@
+fixed_order = ON
+set mt @MT@
+set mz @MZ@
+set mw @MW@
+set ymt @YMT@
+set ebeam1 3500
+set ebeam2 3500
+set pdlabel lhapdf
+set lhaid 324900
+set fixed_ren_scale True
+set fixed_fac_scale True
+set mur_ref_fixed @MT@
+set muf_ref_fixed @MT@
+set reweight_scale True
+set jetalgo -1
+set jetradius 0.5
+set ptj 30.0
+set etaj 4.5
+set req_acc_FO 0.005
+set pineappl True
+done
+quit

--- a/nnpdf31_proc/CMS_SINGLETOP_TCH_R_8TEV_TB/CMS_SINGLETOP_TCH_R_7TEV_TB/output.txt
+++ b/nnpdf31_proc/CMS_SINGLETOP_TCH_R_8TEV_TB/CMS_SINGLETOP_TCH_R_7TEV_TB/output.txt
@@ -1,0 +1,6 @@
+import model loop_qcd_qed_sm_Gmu
+define p = p b b~
+define j = p
+generate p p > t~ j [QCD]
+output @OUTPUT@
+quit

--- a/nnpdf31_proc/CMS_SINGLETOP_TCH_R_8TEV_TB/analysis.f
+++ b/nnpdf31_proc/CMS_SINGLETOP_TCH_R_8TEV_TB/analysis.f
@@ -1,0 +1,43 @@
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_begin(nwgt,weights_info)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      integer nwgt
+      character*(*) weights_info(*)
+
+      call set_error_estimation(1)
+      call HwU_inithist(nwgt,weights_info)
+      call HwU_book(1,'total', 1,0d0,1d0)
+
+      return
+      end
+
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_end(dummy)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      double precision dummy
+      call HwU_write_file
+      return
+      end
+
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine analysis_fill(p,istatus,ipdg,wgts,ibody)
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      implicit none
+      include 'nexternal.inc'
+      integer istatus(nexternal)
+      integer iPDG(nexternal)
+      integer ibody
+      double precision p(0:4,nexternal)
+      double precision wgts(*)
+
+      call HwU_fill(1,0.5d0,wgts)
+
+ 999  return
+      end
+
+ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/nnpdf31_proc/CMS_SINGLETOP_TCH_R_8TEV_TB/launch.txt
+++ b/nnpdf31_proc/CMS_SINGLETOP_TCH_R_8TEV_TB/launch.txt
@@ -1,0 +1,24 @@
+launch @OUTPUT@
+fixed_order = ON
+set mt @MT@
+set mz @MZ@
+set mw @MW@
+set ymt @YMT@
+set ebeam1 4000
+set ebeam2 4000
+set pdlabel lhapdf
+set lhaid 324900
+set fixed_ren_scale True
+set fixed_fac_scale True
+set mur_ref_fixed @MT@
+set muf_ref_fixed @MT@
+set reweight_scale True
+set jetalgo -1
+set jetradius 0.5
+# the following should be ET > 40
+set ptj 40.0
+set etaj 4.5
+set req_acc_FO 0.005
+set pineappl True
+done
+quit

--- a/nnpdf31_proc/CMS_SINGLETOP_TCH_R_8TEV_TB/output.txt
+++ b/nnpdf31_proc/CMS_SINGLETOP_TCH_R_8TEV_TB/output.txt
@@ -1,0 +1,6 @@
+import model loop_qcd_qed_sm_Gmu
+define p = p b b~
+define j = p
+generate p p > t~ j [QCD]
+output @OUTPUT@
+quit


### PR DESCRIPTION
This branch adds the CMS_SINGLETOP_TCH_R datasets with CM energies of 7, 8, and 13 TeV from [arXiv:1209.4533](https://arxiv.org/abs/1209.4533), [arXiv:1403.7366](https://arxiv.org/abs/1403.7366), and [arXiv:1610.00678](https://arxiv.org/abs/1610.00678), with data given in the papers.