### PR TITLE
Pinecards for CMS_WPWM_13TEV_ETA

### DIFF
--- a/NNLOJET_CMS_WPWM_13TEV_ETA/CMS_WPWM_13TEV_ETA_WM.run
+++ b/NNLOJET_CMS_WPWM_13TEV_ETA/CMS_WPWM_13TEV_ETA_WM.run
@@ -1,0 +1,54 @@
+
+!###############################################!
+!##                                           ##!
+!##     _  ___  ____   ____     ____________  ##!
+!##    / |/ / |/ / /  / __ \__ / / __/_  __/  ##!
+!##   /    /    / /__/ /_/ / // / _/  / /     ##!
+!##  /_/|_/_/|_/____/\____/\___/___/ /_/      ##!
+!##                                           ##!
+!##  Runcard for NNPDF datasets               ##!
+!###############################################!
+
+PROCESS  WM
+  collider = pp  sqrts = 13000.0
+  jet = none[0]
+  decay_type = 1
+END_PROCESS
+
+RUN  CMS_WPWM_13TEV_ETA_WM
+  PDF = NNPDF40_nnlo_as_01180[0]
+  tcut = 1e-07
+  scale_coefficients = .true.
+  multi_channel = .false.
+  iseed = 1
+  production = 10000[1]
+END_RUN
+
+PARAMETERS
+MASS[Z] = 91.188
+WIDTH[Z] = 2.4952
+MASS[W] = 80.3692
+WIDTH[W] = 2.085
+SCHEME[alpha] = Gmu
+GF = 1.1663787d-5
+CKM = FULL
+END_PARAMETERS
+
+SELECTORS
+  select abs_ylm  min = 0.0 max = 2.4
+  select ptlm  min = 26.0
+  select etmiss  min = 20.0
+END_SELECTORS
+
+HISTOGRAMS
+  ylm > eta [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.5, 1.7, 1.9, 2.1, 2.4] grid=eta.pine
+
+END_HISTOGRAMS
+
+SCALES
+  mur = etw  muf = etw
+END_SCALES
+
+CHANNELS 
+  LO
+END_CHANNELS

--- a/NNLOJET_CMS_WPWM_13TEV_ETA/CMS_WPWM_13TEV_ETA_WM.yaml
+++ b/NNLOJET_CMS_WPWM_13TEV_ETA/CMS_WPWM_13TEV_ETA_WM.yaml
@@ -1,0 +1,67 @@
+# arXiv number: 2008.04174, hepdata entry: https://www.hepdata.net/record/ins1810913
+
+runname: CMS_WPWM_13TEV_ETA_WM
+
+process:
+    proc: WM
+    sqrts: 13000.0
+
+pdf: NNPDF40_nnlo_as_01180
+
+techcut: 1e-07
+
+histograms:
+  - name: ylm
+    observable: eta
+    bins:
+      - 0.0
+      - 0.1
+      - 0.2
+      - 0.3
+      - 0.4
+      - 0.5
+      - 0.6
+      - 0.7
+      - 0.8
+      - 0.9
+      - 1.0
+      - 1.1
+      - 1.2
+      - 1.3
+      - 1.5
+      - 1.7
+      - 1.9
+      - 2.1
+      - 2.4
+  
+
+multi_channel: 0
+
+channels:
+    LO: LO
+    R: R
+    V: V
+    RR: RR
+    RV: RV
+    VV: VV
+
+parameters:
+    MASS[Z]: 91.188
+    MASS[W]: 80.3692
+    WIDTH[Z]: 2.4952
+    WIDTH[W]: 2.085
+    SCHEME[alpha]: Gmu
+    GF: 1.1663787d-5
+
+selectors:
+  - observable: abs_ylm
+    min: 0.0
+    max: 2.4
+  - observable: ptlm
+    min: 26.0
+  - observable: etmiss
+    min: 20.0
+
+scales:
+    mur: etw
+    muf: etw

--- a/NNLOJET_CMS_WPWM_13TEV_ETA/CMS_WPWM_13TEV_ETA_WP.run
+++ b/NNLOJET_CMS_WPWM_13TEV_ETA/CMS_WPWM_13TEV_ETA_WP.run
@@ -1,0 +1,54 @@
+
+!###############################################!
+!##                                           ##!
+!##     _  ___  ____   ____     ____________  ##!
+!##    / |/ / |/ / /  / __ \__ / / __/_  __/  ##!
+!##   /    /    / /__/ /_/ / // / _/  / /     ##!
+!##  /_/|_/_/|_/____/\____/\___/___/ /_/      ##!
+!##                                           ##!
+!##  Runcard for NNPDF datasets               ##!
+!###############################################!
+
+PROCESS  WP
+  collider = pp  sqrts = 13000.0
+  jet = none[0]
+  decay_type = 1
+END_PROCESS
+
+RUN  CMS_WPWM_13TEV_ETA_WP
+  PDF = NNPDF40_nnlo_as_01180[0]
+  tcut = 1e-07
+  scale_coefficients = .true.
+  multi_channel = .false.
+  iseed = 1
+  production = 10000[1]
+END_RUN
+
+PARAMETERS
+MASS[Z] = 91.188
+WIDTH[Z] = 2.4952
+MASS[W] = 80.3692
+WIDTH[W] = 2.085
+SCHEME[alpha] = Gmu
+GF = 1.1663787d-5
+CKM = FULL
+END_PARAMETERS
+
+SELECTORS
+  select abs_ylp  min = 0.0 max = 2.4
+  select ptlp  min = 26.0
+  select etmiss  min = 20.0
+END_SELECTORS
+
+HISTOGRAMS
+  ylp > eta [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.5, 1.7, 1.9, 2.1, 2.4] grid=eta.pine
+
+END_HISTOGRAMS
+
+SCALES
+  mur = etw  muf = etw
+END_SCALES
+
+CHANNELS 
+  LO
+END_CHANNELS

--- a/NNLOJET_CMS_WPWM_13TEV_ETA/CMS_WPWM_13TEV_ETA_WP.yaml
+++ b/NNLOJET_CMS_WPWM_13TEV_ETA/CMS_WPWM_13TEV_ETA_WP.yaml
@@ -1,0 +1,67 @@
+# arXiv number: 2008.04174, hepdata entry: https://www.hepdata.net/record/ins1810913
+
+runname: CMS_WPWM_13TEV_ETA_WP
+
+process:
+    proc: WP
+    sqrts: 13000.0
+
+pdf: NNPDF40_nnlo_as_01180
+
+techcut: 1e-07
+
+histograms:
+  - name: ylp
+    observable: eta
+    bins:
+      - 0.0
+      - 0.1
+      - 0.2
+      - 0.3
+      - 0.4
+      - 0.5
+      - 0.6
+      - 0.7
+      - 0.8
+      - 0.9
+      - 1.0
+      - 1.1
+      - 1.2
+      - 1.3
+      - 1.5
+      - 1.7
+      - 1.9
+      - 2.1
+      - 2.4
+  
+
+multi_channel: 0
+
+channels:
+    LO: LO
+    R: R
+    V: V
+    RR: RR
+    RV: RV
+    VV: VV
+
+parameters:
+    MASS[Z]: 91.188
+    MASS[W]: 80.3692
+    WIDTH[Z]: 2.4952
+    WIDTH[W]: 2.085
+    SCHEME[alpha]: Gmu
+    GF: 1.1663787d-5
+
+selectors:
+  - observable: abs_ylp
+    min: 0.0
+    max: 2.4
+  - observable: ptlp
+    min: 26.0
+  - observable: etmiss
+    min: 20.0
+
+scales:
+    mur: etw
+    muf: etw

--- a/NNLOJET_CMS_WPWM_13TEV_ETA/metadata.txt
+++ b/NNLOJET_CMS_WPWM_13TEV_ETA/metadata.txt
@@ -1,0 +1,12 @@
+arxiv=2008.04174
+hepdata=https://www.hepdata.net/record/ins1810913
+nnpdf_id=CMS_WPWM_13TEV_ETA
+description=CMS 13 TeV, differential cross section in W+ > l+ v boson pseudo rapidity. Combination of muon and electron channel
+x1_label=eta
+x1_label_tex=
+x2_label=
+x2_label_tex=
+x2_unit=
+y_label=
+y_label_tex=r"$d\\sigma/d|\eta|$"
+y_unit="[pb]"


### PR DESCRIPTION
This PR adds the pinecards and NNLOJET runcards used to produce the grids for the  CMS_WPWM_13TEV_ETA dataset